### PR TITLE
修复序列化配置不一致导致消息队列处理异常。

### DIFF
--- a/src/EasyAbp.Abp.EventBus.CAP/AbpJsonSerializer.cs
+++ b/src/EasyAbp.Abp.EventBus.CAP/AbpJsonSerializer.cs
@@ -4,23 +4,26 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Serialization;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using Volo.Abp.Json;
+using Volo.Abp.Json.SystemTextJson;
 
 namespace EasyAbp.Abp.EventBus.Cap;
 
 public class AbpJsonSerializer : ISerializer
 {
+    public static bool CamelCase;
     private readonly IJsonSerializer _jsonSerializer;
-
-    public AbpJsonSerializer(IJsonSerializer jsonSerializer)
+    public AbpJsonSerializer(IJsonSerializer jsonSerializer, IOptions<AbpSystemTextJsonSerializerOptions> jsonOptions)
     {
         _jsonSerializer = jsonSerializer;
+        CamelCase = jsonOptions.Value.JsonSerializerOptions.PropertyNamingPolicy == null ? false : true;
     }
 
     public virtual string Serialize(Message message)
     {
-        return _jsonSerializer.Serialize(message);
+        return _jsonSerializer.Serialize(message, CamelCase);
     }
 
     public virtual ValueTask<TransportMessage> SerializeAsync(Message message)
@@ -35,14 +38,14 @@ public class AbpJsonSerializer : ISerializer
             return new ValueTask<TransportMessage>(new TransportMessage(message.Headers, null));
         }
 
-        var json = _jsonSerializer.Serialize(message.Value);
+        var json = _jsonSerializer.Serialize(message.Value, CamelCase);
 
         return new ValueTask<TransportMessage>(new TransportMessage(message.Headers, Encoding.UTF8.GetBytes(json)));
     }
 
     public virtual Message Deserialize(string json)
     {
-        return _jsonSerializer.Deserialize<Message>(json);
+        return _jsonSerializer.Deserialize<Message>(json, CamelCase);
     }
 
     public virtual ValueTask<Message> DeserializeAsync(TransportMessage transportMessage, Type valueType)
@@ -55,12 +58,12 @@ public class AbpJsonSerializer : ISerializer
         var json = Encoding.UTF8.GetString(transportMessage.Body.ToArray());
 
         return new ValueTask<Message>(new Message(transportMessage.Headers,
-            _jsonSerializer.Deserialize(valueType, json)));
+            _jsonSerializer.Deserialize(valueType, json, CamelCase)));
     }
 
     public virtual object Deserialize(object value, Type valueType)
     {
-        return _jsonSerializer.Deserialize(valueType, value.ToString());
+        return _jsonSerializer.Deserialize(valueType, value.ToString(), CamelCase);
     }
 
     public virtual bool IsJsonType(object jsonObject)

--- a/src/EasyAbp.Abp.EventBus.CAP/AbpJsonSerializer.cs
+++ b/src/EasyAbp.Abp.EventBus.CAP/AbpJsonSerializer.cs
@@ -18,7 +18,7 @@ public class AbpJsonSerializer : ISerializer
     public AbpJsonSerializer(IJsonSerializer jsonSerializer, IOptions<AbpSystemTextJsonSerializerOptions> jsonOptions)
     {
         _jsonSerializer = jsonSerializer;
-        CamelCase = jsonOptions.Value.JsonSerializerOptions.PropertyNamingPolicy == null ? false : true;
+        CamelCase = jsonOptions.Value.JsonSerializerOptions.PropertyNamingPolicy != null;
     }
 
     public virtual string Serialize(Message message)


### PR DESCRIPTION
由于SystemTextJson严格的序列化模式，当消息发送端和接收端序列化CamelCase配置不一致时，接收端接收消息会出现序列化异常，出现null的情况。所以JsonSerializer需要考虑CamelCase传参。